### PR TITLE
Fix NuGet packages discovery for some IDEs

### DIFF
--- a/CryptoExchange.Net.UnitTests/CryptoExchange.Net.UnitTests.csproj
+++ b/CryptoExchange.Net.UnitTests/CryptoExchange.Net.UnitTests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <packagereference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211130-02"></packagereference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-preview-20211130-02"></PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <packagereference Include="NUnit" Version="3.13.2"></packagereference>
-    <packagereference Include="NUnit3TestAdapter" Version="4.2.0"></packagereference>
+    <PackageReference Include="NUnit" Version="3.13.2"></PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0"></PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This simple PR fixes build in JetBrains Rider and closes the https://github.com/JKorf/CryptoExchange.Net/issues/142  

Problem: Rider does not process NuGet restore if `PackageReference` XML tag is in wrong case (inside `csproj` file) at this time.